### PR TITLE
Remove onWindowFocusChanged function override

### DIFF
--- a/android/KioskActivity.java
+++ b/android/KioskActivity.java
@@ -44,17 +44,17 @@ public class KioskActivity extends CordovaActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         super.init();
-        
+
         if (running) {
             finish(); // prevent more instances of kiosk activity
         }
-        
+
         loadUrl(launchUrl);
-        
+
         // https://github.com/apache/cordova-plugin-statusbar/blob/master/src/android/StatusBar.java
         getWindow().clearFlags(WindowManager.LayoutParams.FLAG_FORCE_NOT_FULLSCREEN);
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN);
-        
+
         // https://github.com/hkalina/cordova-plugin-kiosk/issues/14
         View decorView = getWindow().getDecorView();
         // Hide the status bar.
@@ -63,7 +63,7 @@ public class KioskActivity extends CordovaActivity {
         // status bar is hidden, so hide that too if necessary.
         ActionBar actionBar = getActionBar();
         if (actionBar != null) actionBar.hide();
-        
+
         // add overlay to prevent statusbar access by swiping
         statusBarOverlay = StatusBarOverlay.createOrObtainPermission(this);
     }
@@ -81,30 +81,6 @@ public class KioskActivity extends CordovaActivity {
     public boolean onKeyDown(int keyCode, KeyEvent event) {
         System.out.println("onKeyDown event: keyCode = " + event.getKeyCode());
         return ! allowedKeys.contains(event.getKeyCode()); // prevent event from being propagated if not allowed
-    }
-
-    // http://www.andreas-schrade.de/2015/02/16/android-tutorial-how-to-create-a-kiosk-mode-in-android/
-    @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-        if(!hasFocus) {
-            System.out.println("Focus lost - closing system dialogs");
-            
-            Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
-            sendBroadcast(closeDialog);
-            
-            ActivityManager am = (ActivityManager)getSystemService(Context.ACTIVITY_SERVICE);
-            am.moveTaskToFront(getTaskId(), ActivityManager.MOVE_TASK_WITH_HOME);
-            
-            // sometime required to close opened notification area
-            Timer timer = new Timer();
-            timer.schedule(new TimerTask(){
-                public void run() {
-                    Intent closeDialog = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
-                    sendBroadcast(closeDialog);
-                }
-            }, 500); // 0.5 second
-        }
     }
 }
 


### PR DESCRIPTION
For https://github.com/Medology/raven-scanner-app/issues/165

The problem
When long pressing the power button on the Avision scanner, the Kiosk
plugin prevents the system dialog from being shown, which allows the
user to shut down or reboot the device.

The solution
Remove the `onWindowFocusChanged` override function that causes the
system dialog to auto-close.