### PR TITLE
Stop StatusBarOverlay

### DIFF
--- a/android/KioskActivity.java
+++ b/android/KioskActivity.java
@@ -63,9 +63,6 @@ public class KioskActivity extends CordovaActivity {
         // status bar is hidden, so hide that too if necessary.
         ActionBar actionBar = getActionBar();
         if (actionBar != null) actionBar.hide();
-
-        // add overlay to prevent statusbar access by swiping
-        // statusBarOverlay = StatusBarOverlay.createOrObtainPermission(this);
     }
 
     @Override

--- a/android/KioskActivity.java
+++ b/android/KioskActivity.java
@@ -65,7 +65,7 @@ public class KioskActivity extends CordovaActivity {
         if (actionBar != null) actionBar.hide();
 
         // add overlay to prevent statusbar access by swiping
-        statusBarOverlay = StatusBarOverlay.createOrObtainPermission(this);
+        // statusBarOverlay = StatusBarOverlay.createOrObtainPermission(this);
     }
 
     @Override


### PR DESCRIPTION
For: https://github.com/StarfishCo/raven-scanner-app/issues/638

There was a hidden statuBarOverlay which was causing the top part of the screen to be unused.