### PR TITLE
Add uncaught exception handler

### DIFF
--- a/android/KioskActivity.java
+++ b/android/KioskActivity.java
@@ -118,7 +118,6 @@ public class KioskActivity extends CordovaActivity {
             PendingIntent pendingIntent = PendingIntent.getActivity(activity.getApplicationContext(), 666, intent, PendingIntent.FLAG_ONE_SHOT);
             AlarmManager mgr = (AlarmManager) activity.getSystemService(Context.ALARM_SERVICE);
             mgr.set(AlarmManager.RTC, System.currentTimeMillis() +  500, pendingIntent);
-            running = false;
             activity.finish();
             System.exit(2);
         }


### PR DESCRIPTION
For #1387

- Adds uncaught exception handler to `KioskActivity`'s Thread (main activity of application) 
- This will catch uncaught exceptions that would otherwise cause the app to crash. We then auto restart the application using an alarm so that users aren't exposed to the android system